### PR TITLE
Patched the desktop definition

### DIFF
--- a/qubes-doc.desktop
+++ b/qubes-doc.desktop
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Name=Qubes OS Offline Documentation
 Type=Application
 Exec=evince /usr/share/qubes/qubes-doc.pdf
 Icon=qubes-manager


### PR DESCRIPTION
When installing this package on a Fedora 37 VM the desktop definition is created but isn't recognized by the applications list in the Qubes management UI so I patched the desktop definition by specifying an application name so that the built and installed version of this package is displayed in the applications menu by default.